### PR TITLE
Flutter 3 compatible and enable drag from the homescreen as well

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/integration_test/home_screen_test.dart
+++ b/integration_test/home_screen_test.dart
@@ -39,7 +39,7 @@ void main() {
       expect(find.byType(AppsView).hitTestable(), findsNothing);
     });
     testWidgets(
-        'Swiping up on the upper part of the home screen should not open app drawer',
+        'Swiping up on the upper part of the home screen should open app drawer',
         (WidgetTester tester) async {
       await app.main();
       await tester.pumpAndSettle();
@@ -55,8 +55,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // Then:
-      // app drawer is not opened
-      expect(find.byType(AppsView).hitTestable(), findsNothing);
+      // app drawer is opened
+      expect(find.byType(AppsView).hitTestable(), findsWidgets);
     });
     testWidgets('Swiping up on the dock should open app drawer',
         (WidgetTester tester) async {

--- a/lib/home/home_screen.dart
+++ b/lib/home/home_screen.dart
@@ -62,6 +62,13 @@ class HomeScreen extends ConsumerWidget {
               return GestureDetector(
                 behavior: HitTestBehavior.translucent,
                 onLongPress: () => context.push(OverviewScreen.routeName),
+                onVerticalDragEnd: (details) {
+                  final primaryVelocity = details.primaryVelocity ?? 0;
+                  // on swipe up
+                  if (primaryVelocity < 0) {
+                    Backdrop.of(context).concealBackLayer();
+                  }
+                },
                 child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
@@ -79,14 +86,7 @@ class HomeScreen extends ConsumerWidget {
                           flex: dockRowCount,
                           child: GestureDetector(
                             behavior: HitTestBehavior.translucent,
-                            onVerticalDragEnd: (details) {
-                              final primaryVelocity =
-                                  details.primaryVelocity ?? 0;
-                              // on swipe up
-                              if (primaryVelocity < 0) {
-                                Backdrop.of(context).concealBackLayer();
-                              }
-                            },
+                            
                             child: const Dock(),
                           ))
                     ]),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -360,10 +360,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -432,18 +432,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -645,10 +645,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -709,10 +709,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   time:
     dependency: transitive
     description:
@@ -845,10 +845,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
+      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.0"
+    version: "11.7.1"
   watcher:
     dependency: transitive
     description:
@@ -857,6 +857,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -914,5 +922,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.7.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.2.10+1
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hey, I found your app on F-Droid and really liked it.

Wanted to contribute a bit and as an "end-user" I found out, that I could only drag the App-Drawer from the very bottom, the dock, which isn't very user-friendly as I'm used to being able to swipe from anywhere up and see my drawer (Googles own Launcher has that). Therefore I used the "onVerticalDragEnd" method on the whole backlayer and not just on the dock.

And on the fly, I made the app flutter 3+ compatible (just changed the flutter version on top and ran your tests and tested myself).

Hope you find my changes reasonable and keep forward.

Emre